### PR TITLE
Bugfix for copy by value

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -23,6 +23,11 @@ namespace Polygon_Decomposition {
     T &at(std::vector<T>& v, int i) {
         return v[wrap(i, v.size())];
     };
+    
+    template<class T>
+    const T &at(const std::vector<T>& v, int i) {
+        return v[wrap(i, v.size())];
+    };
 
 }
 #endif

--- a/include/common.h
+++ b/include/common.h
@@ -20,7 +20,7 @@ namespace Polygon_Decomposition {
     // Scalar srand(const Scalar &min, const Scalar &max);
 
     template<class T>
-    const T &at(const std::vector<T>& v, int i) {
+    T &at(std::vector<T>& v, int i) {
         return v[wrap(i, v.size())];
     };
 

--- a/include/common.h
+++ b/include/common.h
@@ -20,7 +20,7 @@ namespace Polygon_Decomposition {
     // Scalar srand(const Scalar &min, const Scalar &max);
 
     template<class T>
-    T &at(std::vector<T> v, int i) {
+    const T &at(const std::vector<T>& v, int i) {
         return v[wrap(i, v.size())];
     };
 


### PR DESCRIPTION
Without this, you're returning a reference to a function-local variable which is invalid.